### PR TITLE
feat: error codes & validate targets

### DIFF
--- a/test/resolve.js
+++ b/test/resolve.js
@@ -612,3 +612,49 @@ conditions('should throw an error if no known conditions', ctx => {
 });
 
 conditions.run();
+
+// ---
+
+const validation = suite('validation', {
+	"name": "foobar",
+	"exports": {
+		"browser": "/$require",
+		"import": "$prod",
+		"require": "../$require",
+	}
+});
+
+validation('throws `ERR_INVALID_PACKAGE_TARGET` error :: "target"', pkg => {
+	try {
+		$exports.resolve(pkg);
+		assert.unreachable();
+	} catch (err) {
+		assert.instance(err, Error);
+		assert.is(err.code, 'ERR_INVALID_PACKAGE_TARGET');
+		assert.is(err.message, `Invalid "." export in "foobar" package; targets must start with "./"`);
+	}
+});
+
+validation('throws `ERR_INVALID_PACKAGE_TARGET` error :: "../target"', pkg => {
+	try {
+		$exports.resolve(pkg, '.', { require: true });
+		assert.unreachable();
+	} catch (err) {
+		assert.instance(err, Error);
+		assert.is(err.code, 'ERR_INVALID_PACKAGE_TARGET');
+		assert.is(err.message, `Invalid "." export in "foobar" package; targets must start with "./"`);
+	}
+});
+
+validation('throws `ERR_INVALID_PACKAGE_TARGET` error :: "/target"', pkg => {
+	try {
+		$exports.resolve(pkg, '.', { browser: true });
+		assert.unreachable();
+	} catch (err) {
+		assert.instance(err, Error);
+		assert.is(err.code, 'ERR_INVALID_PACKAGE_TARGET');
+		assert.is(err.message, `Invalid "." export in "foobar" package; targets must start with "./"`);
+	}
+});
+
+validation.run();

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -28,12 +28,12 @@ resolve('should be a function', () => {
 resolve('exports=string', () => {
 	let pkg = {
 		"name": "foobar",
-		"exports": "$string",
+		"exports": "./$string",
 	};
 
-	pass(pkg, '$string');
-	pass(pkg, '$string', '.');
-	pass(pkg, '$string', 'foobar');
+	pass(pkg, './$string');
+	pass(pkg, './$string', '.');
+	pass(pkg, './$string', 'foobar');
 
 	fail(pkg, './other', 'other');
 	fail(pkg, './other', 'foobar/other');
@@ -44,14 +44,14 @@ resolve('exports = { self }', () => {
 	let pkg = {
 		"name": "foobar",
 		"exports": {
-			"import": "$import",
-			"require": "$require",
+			"import": "./$import",
+			"require": "./$require",
 		}
 	};
 
-	pass(pkg, '$import');
-	pass(pkg, '$import', '.');
-	pass(pkg, '$import', 'foobar');
+	pass(pkg, './$import');
+	pass(pkg, './$import', '.');
+	pass(pkg, './$import', 'foobar');
 
 	fail(pkg, './other', 'other');
 	fail(pkg, './other', 'foobar/other');
@@ -62,13 +62,13 @@ resolve('exports["."] = string', () => {
 	let pkg = {
 		"name": "foobar",
 		"exports": {
-			".": "$self",
+			".": "./$self",
 		}
 	};
 
-	pass(pkg, '$self');
-	pass(pkg, '$self', '.');
-	pass(pkg, '$self', 'foobar');
+	pass(pkg, './$self');
+	pass(pkg, './$self', '.');
+	pass(pkg, './$self', 'foobar');
 
 	fail(pkg, './other', 'other');
 	fail(pkg, './other', 'foobar/other');
@@ -80,15 +80,15 @@ resolve('exports["."] = object', () => {
 		"name": "foobar",
 		"exports": {
 			".": {
-				"import": "$import",
-				"require": "$require",
+				"import": "./$import",
+				"require": "./$require",
 			}
 		}
 	};
 
-	pass(pkg, '$import');
-	pass(pkg, '$import', '.');
-	pass(pkg, '$import', 'foobar');
+	pass(pkg, './$import');
+	pass(pkg, './$import', '.');
+	pass(pkg, './$import', 'foobar');
 
 	fail(pkg, './other', 'other');
 	fail(pkg, './other', 'foobar/other');
@@ -99,12 +99,12 @@ resolve('exports["./foo"] = string', () => {
 	let pkg = {
 		"name": "foobar",
 		"exports": {
-			"./foo": "$import",
+			"./foo": "./$import",
 		}
 	};
 
-	pass(pkg, '$import', './foo');
-	pass(pkg, '$import', 'foobar/foo');
+	pass(pkg, './$import', './foo');
+	pass(pkg, './$import', 'foobar/foo');
 
 	fail(pkg, '.');
 	fail(pkg, '.', 'foobar');
@@ -116,14 +116,14 @@ resolve('exports["./foo"] = object', () => {
 		"name": "foobar",
 		"exports": {
 			"./foo": {
-				"import": "$import",
-				"require": "$require",
+				"import": "./$import",
+				"require": "./$require",
 			}
 		}
 	};
 
-	pass(pkg, '$import', './foo');
-	pass(pkg, '$import', 'foobar/foo');
+	pass(pkg, './$import', './foo');
+	pass(pkg, './$import', 'foobar/foo');
 
 	fail(pkg, '.');
 	fail(pkg, '.', 'foobar');
@@ -136,19 +136,19 @@ resolve('nested conditions', () => {
 		"name": "foobar",
 		"exports": {
 			"node": {
-				"import": "$node.import",
-				"require": "$node.require"
+				"import": "./$node.import",
+				"require": "./$node.require"
 			},
-			"default": "$default",
+			"default": "./$default",
 		}
 	};
 
-	pass(pkg, '$node.import');
-	pass(pkg, '$node.import', 'foobar');
+	pass(pkg, './$node.import');
+	pass(pkg, './$node.import', 'foobar');
 
 	// browser => no "node" key
-	pass(pkg, '$default', '.', { browser: true });
-	pass(pkg, '$default', 'foobar', { browser: true });
+	pass(pkg, './$default', '.', { browser: true });
+	pass(pkg, './$default', 'foobar', { browser: true });
 
 	fail(pkg, './hello', './hello');
 	fail(pkg, './other', 'foobar/other');
@@ -161,22 +161,22 @@ resolve('nested conditions :: subpath', () => {
 		"exports": {
 			"./lite": {
 				"node": {
-					"import": "$node.import",
-					"require": "$node.require"
+					"import": "./$node.import",
+					"require": "./$node.require"
 				},
 				"browser": {
-					"import": "$browser.import",
-					"require": "$browser.require"
+					"import": "./$browser.import",
+					"require": "./$browser.require"
 				},
 			}
 		}
 	};
 
-	pass(pkg, '$node.import', 'foobar/lite');
-	pass(pkg, '$node.require', 'foobar/lite', { require: true });
+	pass(pkg, './$node.import', 'foobar/lite');
+	pass(pkg, './$node.require', 'foobar/lite', { require: true });
 
-	pass(pkg, '$browser.import', 'foobar/lite', { browser: true });
-	pass(pkg, '$browser.require', 'foobar/lite', { browser: true, require: true });
+	pass(pkg, './$browser.import', 'foobar/lite', { browser: true });
+	pass(pkg, './$browser.require', 'foobar/lite', { browser: true, require: true });
 });
 
 resolve('nested conditions :: subpath :: inverse', () => {
@@ -185,22 +185,22 @@ resolve('nested conditions :: subpath :: inverse', () => {
 		"exports": {
 			"./lite": {
 				"import": {
-					"browser": "$browser.import",
-					"node": "$node.import",
+					"browser": "./$browser.import",
+					"node": "./$node.import",
 				},
 				"require": {
-					"browser": "$browser.require",
-					"node": "$node.require",
+					"browser": "./$browser.require",
+					"node": "./$node.require",
 				}
 			}
 		}
 	};
 
-	pass(pkg, '$node.import', 'foobar/lite');
-	pass(pkg, '$node.require', 'foobar/lite', { require: true });
+	pass(pkg, './$node.import', 'foobar/lite');
+	pass(pkg, './$node.require', 'foobar/lite', { require: true });
 
-	pass(pkg, '$browser.import', 'foobar/lite', { browser: true });
-	pass(pkg, '$browser.require', 'foobar/lite', { browser: true, require: true });
+	pass(pkg, './$browser.import', 'foobar/lite', { browser: true });
+	pass(pkg, './$browser.require', 'foobar/lite', { browser: true, require: true });
 });
 
 // https://nodejs.org/api/packages.html#packages_subpath_folder_mappings
@@ -209,17 +209,17 @@ resolve('exports["./"]', () => {
 		"name": "foobar",
 		"exports": {
 			".": {
-				"require": "$require",
-				"import": "$import"
+				"require": "./$require",
+				"import": "./$import"
 			},
 			"./package.json": "./package.json",
 			"./": "./"
 		}
 	};
 
-	pass(pkg, '$import');
-	pass(pkg, '$import', 'foobar');
-	pass(pkg, '$require', 'foobar', { require: true });
+	pass(pkg, './$import');
+	pass(pkg, './$import', 'foobar');
+	pass(pkg, './$require', 'foobar', { require: true });
 
 	pass(pkg, './package.json', 'package.json');
 	pass(pkg, './package.json', 'foobar/package.json');
@@ -468,29 +468,29 @@ resolve('should handle mixed path/conditions', () => {
 		"exports": {
 			".": [
 				{
-					"import": "$root.import",
+					"import": "./$root.import",
 				},
-				"$root.string"
+				"./$root.string"
 			],
 			"./foo": [
 				{
-					"require": "$foo.require"
+					"require": "./$foo.require"
 				},
-				"$foo.string"
+				"./$foo.string"
 			]
 		}
 	}
 
-	pass(pkg, '$root.import');
-	pass(pkg, '$root.import', 'foobar');
+	pass(pkg, './$root.import');
+	pass(pkg, './$root.import', 'foobar');
 
-	pass(pkg, '$foo.string', 'foo');
-	pass(pkg, '$foo.string', 'foobar/foo');
-	pass(pkg, '$foo.string', './foo');
+	pass(pkg, './$foo.string', 'foo');
+	pass(pkg, './$foo.string', 'foobar/foo');
+	pass(pkg, './$foo.string', './foo');
 
-	pass(pkg, '$foo.require', 'foo', { require: true });
-	pass(pkg, '$foo.require', 'foobar/foo', { require: true });
-	pass(pkg, '$foo.require', './foo', { require: true });
+	pass(pkg, './$foo.require', 'foo', { require: true });
+	pass(pkg, './$foo.require', 'foobar/foo', { require: true });
+	pass(pkg, './$foo.require', './foo', { require: true });
 });
 
 resolve.run();
@@ -499,38 +499,38 @@ resolve.run();
 
 const requires = suite('options.requires', {
 	"exports": {
-		"require": "$require",
-		"import": "$import",
+		"require": "./$require",
+		"import": "./$import",
 	}
 });
 
 requires('should ignore "require" keys by default', pkg => {
-	pass(pkg, '$import');
+	pass(pkg, './$import');
 });
 
 requires('should use "require" key when defined first', pkg => {
-	pass(pkg, '$require', '.', { require: true });
+	pass(pkg, './$require', '.', { require: true });
 });
 
 requires('should ignore "import" key when enabled', () => {
 	let pkg = {
 		"exports": {
-			"import": "$import",
-			"require": "$require",
+			"import": "./$import",
+			"require": "./$require",
 		}
 	};
-	pass(pkg, '$require', '.', { require: true });
-	pass(pkg, '$import', '.');
+	pass(pkg, './$require', '.', { require: true });
+	pass(pkg, './$import', '.');
 });
 
 requires('should match "default" if "require" is after', () => {
 	let pkg = {
 		"exports": {
-			"default": "$default",
-			"require": "$require",
+			"default": "./$default",
+			"require": "./$require",
 		}
 	};
-	pass(pkg, '$default', '.', { require: true });
+	pass(pkg, './$default', '.', { require: true });
 });
 
 requires.run();
@@ -539,29 +539,29 @@ requires.run();
 
 const browser = suite('options.browser', {
 	"exports": {
-		"browser": "$browser",
-		"node": "$node",
+		"browser": "./$browser",
+		"node": "./$node",
 	}
 });
 
 browser('should ignore "browser" keys by default', pkg => {
-	pass(pkg, '$node');
+	pass(pkg, './$node');
 });
 
 browser('should use "browser" key when defined first', pkg => {
-	pass(pkg, '$browser', '.', { browser: true });
+	pass(pkg, './$browser', '.', { browser: true });
 });
 
 browser('should ignore "node" key when enabled', () => {
 	let pkg = {
 		"exports": {
-			"node": "$node",
-			"import": "$import",
-			"browser": "$browser",
+			"node": "./$node",
+			"import": "./$import",
+			"browser": "./$browser",
 		}
 	};
 	// import defined before browser
-	pass(pkg, '$import', '.', { browser: true });
+	pass(pkg, './$import', '.', { browser: true });
 });
 
 browser.run();
@@ -570,22 +570,22 @@ browser.run();
 
 const conditions = suite('options.conditions', {
 	"exports": {
-		"production": "$prod",
-		"development": "$dev",
-		"default": "$default",
+		"production": "./$prod",
+		"development": "./$dev",
+		"default": "./$default",
 	}
 });
 
 conditions('should ignore unknown conditions by default', pkg => {
-	pass(pkg, '$default');
+	pass(pkg, './$default');
 });
 
 conditions('should recognize custom field(s) when specified', pkg => {
-	pass(pkg, '$dev', '.', {
+	pass(pkg, './$dev', '.', {
 		conditions: ['development']
 	});
 
-	pass(pkg, '$prod', '.', {
+	pass(pkg, './$prod', '.', {
 		conditions: ['development', 'production']
 	});
 });

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -13,6 +13,7 @@ function fail(pkg, target, ...args) {
 		assert.unreachable();
 	} catch (err) {
 		assert.instance(err, Error);
+		assert.is(err.code, 'ERR_PACKAGE_PATH_NOT_EXPORTED');
 		assert.is(err.message, `Missing "${target}" export in "${pkg.name}" package`);
 	}
 }
@@ -605,6 +606,7 @@ conditions('should throw an error if no known conditions', ctx => {
 		assert.unreachable();
 	} catch (err) {
 		assert.instance(err, Error);
+		assert.is(err.code, 'ERR_PACKAGE_PATH_NOT_EXPORTED');
 		assert.is(err.message, `No known conditions for "." entry in "hello" package`);
 	}
 });


### PR DESCRIPTION
Added error codes (matching Node.js' codes) – and retracted my stance on #5 for now – at least to see how it looks. This does, however raise the question of how directory targets should be handled. Node.js throws `ERR_UNSUPPORTED_DIR_IMPORT` but _I think_ this is because of [its file-system stage](https://github.com/nodejs/node/blob/2af43f65055de2817eb7907d3a3d3b3a3de127f5/lib/internal/modules/esm/resolve.js#L300-L309) – and **not** because it's an invalid `"exports"` target.

While Node has this [_marked_ for deprecation](https://nodejs.org/api/packages.html#packages_subpath_folder_mappings), it's not actually deprecated yet. 
I'm fairly certain this means that the pattern is still _valid_ and may be in use by others? Specifically, this:

```js
{
  "exports": {
    "./features/": "./features/", // <~ this
    "./": "./", // <~ NOT this – it's special
  }
}
```

> I believe Vite relies on this?

Apologize for the pings, but would very much appreciate the sanity check here so that there can be agreement moving forward. /cc @developit @MylesBorins @paul-soporan @yyx990803 @fredkschott 