### PR TITLE
feat(ts): allow `readonly` arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 export type Options = {
 	browser?: boolean;
-	conditions?: string[];
+	conditions?: readonly string[];
 	require?: boolean;
 	unsafe?: false;
 } | {
-	conditions?: string[];
+	conditions?: readonly string[];
 	unsafe?: true;
 }
 
@@ -12,10 +12,10 @@ export function resolve<T=any>(pkg: T, entry: string, options?: Options): string
 
 export type BrowserFiles = Record<string, string | false>;
 
-export function legacy<T=any>(pkg: T, options: { browser: true, fields?: string[] }): BrowserFiles | string | void;
-export function legacy<T=any>(pkg: T, options: { browser: string, fields?: string[] }): string | false | void;
-export function legacy<T=any>(pkg: T, options: { browser: false, fields?: string[] }): string | void;
+export function legacy<T=any>(pkg: T, options: { browser: true, fields?: readonly string[] }): BrowserFiles | string | void;
+export function legacy<T=any>(pkg: T, options: { browser: string, fields?: readonly string[] }): string | false | void;
+export function legacy<T=any>(pkg: T, options: { browser: false, fields?: readonly string[] }): string | void;
 export function legacy<T=any>(pkg: T, options?: {
 	browser?: boolean | string;
-	fields?: string[];
+	fields?: readonly string[];
 }): BrowserFiles | string | false | void;


### PR DESCRIPTION
Consumers can still pass mutable ones as they extend with mutable functions, but this allows be to also pass readonly ones