### PR TITLE
fix: add `types` condition to `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
The TypeScript 4.7 beta in `Node12` / `NodeNext` mode doesn't look at the `types` field when `exports` is specified so I added the `types` condition to the `exports` field to make it able to locate the types.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#package-json-exports-imports-and-self-referencing