### PR TITLE
tests: Invert comments on pattern trailer handling, extend test values

### DIFF
--- a/test/resolve.js
+++ b/test/resolve.js
@@ -382,11 +382,11 @@ resolve('exports["./features/*"]', () => {
 	pass(pkg, './features/abc.js', 'foobar/features/abc');
 
 	pass(pkg, './features/hello.js', 'foobar/features/hello');
-	pass(pkg, './features/world.js', 'foobar/features/world');
+	pass(pkg, './features/hello/world.js', 'foobar/features/hello/world');
 
-	// incorrect, but matches Node. evaluate as defined
+	// Valid: Pattern trailers allow any exact substrings to be matched
 	pass(pkg, './features/hello.js.js', 'foobar/features/hello.js');
-	pass(pkg, './features/world.js.js', 'foobar/features/world.js');
+	pass(pkg, './features/hello/world.js.js', 'foobar/features/hello/world.js');
 
 	fail(pkg, './package.json', 'package.json');
 	fail(pkg, './package.json', 'foobar/package.json');
@@ -410,11 +410,11 @@ resolve('exports["./features/*"] :: with "./" key', () => {
 	pass(pkg, './features/', 'foobar/features/'); // via "./"
 
 	pass(pkg, './features/hello.js', 'foobar/features/hello');
-	pass(pkg, './features/world.js', 'foobar/features/world');
+	pass(pkg, './features/hello/world.js', 'foobar/features/hello/world');
 
-	// incorrect, but matches Node. evaluate as defined
+	// Valid: Pattern trailers allow any exact substrings to be matched
 	pass(pkg, './features/hello.js.js', 'foobar/features/hello.js');
-	pass(pkg, './features/world.js.js', 'foobar/features/world.js');
+	pass(pkg, './features/hello/world.js.js', 'foobar/features/hello/world.js');
 
 	pass(pkg, './package.json', 'package.json');
 	pass(pkg, './package.json', 'foobar/package.json');

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -382,11 +382,11 @@ resolve('exports["./features/*"]', () => {
 	pass(pkg, './features/abc.js', 'foobar/features/abc');
 
 	pass(pkg, './features/hello.js', 'foobar/features/hello');
-	pass(pkg, './features/hello/world.js', 'foobar/features/hello/world');
+	pass(pkg, './features/foo/bar.js', 'foobar/features/foo/bar');
 
 	// Valid: Pattern trailers allow any exact substrings to be matched
 	pass(pkg, './features/hello.js.js', 'foobar/features/hello.js');
-	pass(pkg, './features/hello/world.js.js', 'foobar/features/hello/world.js');
+	pass(pkg, './features/foo/bar.js.js', 'foobar/features/foo/bar.js');
 
 	fail(pkg, './package.json', 'package.json');
 	fail(pkg, './package.json', 'foobar/package.json');
@@ -410,11 +410,11 @@ resolve('exports["./features/*"] :: with "./" key', () => {
 	pass(pkg, './features/', 'foobar/features/'); // via "./"
 
 	pass(pkg, './features/hello.js', 'foobar/features/hello');
-	pass(pkg, './features/hello/world.js', 'foobar/features/hello/world');
+	pass(pkg, './features/foo/bar.js', 'foobar/features/foo/bar');
 
 	// Valid: Pattern trailers allow any exact substrings to be matched
 	pass(pkg, './features/hello.js.js', 'foobar/features/hello.js');
-	pass(pkg, './features/hello/world.js.js', 'foobar/features/hello/world.js');
+	pass(pkg, './features/foo/bar.js.js', 'foobar/features/foo/bar.js');
 
 	pass(pkg, './package.json', 'package.json');
 	pass(pkg, './package.json', 'foobar/package.json');


### PR DESCRIPTION
Hey, I've been looking through the tests for this library and spotted something which I'd interpreted differently in the spec. Specifically, the behaviour of _pattern trailers_ for subpath exports, described in more detail here: https://github.com/nodejs/node/pull/39635.

Changes:
- Change the two relevant comments in tests
- Extend test values for subpath exports to include an intermediate subdirectory

