### PR TITLE
docs(readme): fix small typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ const pkg = {
     },
     "./lite": {
       "worker": {
-        "browser": "./lite/worker.brower.js",
+        "browser": "./lite/worker.browser.js",
         "node": "./lite/worker.node.js"
       },
       "import": "./lite/module.mjs",


### PR DESCRIPTION
Hi there, thanks for your work on this package, it's been super useful. As I was adapting some of the readme examples to one of my unit tests, I noticed what I assume is a small typo. This tiny little PR fixes it.