### PR TITLE
fix: avoid lazy regexp matching

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ export function walk(name: string, mapping: Mapping, input: string, options?: t.
 
 				if (!!~tmp) {
 					match = RegExp(
-						'^' + key.substring(0, tmp) + '(.*)' + key.substring(1+tmp)
+						'^' + key.substring(0, tmp) + '(.*)' + key.substring(1+tmp) + '$'
 					).exec(entry);
 
 					if (match && match[1]) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -635,6 +635,18 @@ describe('$.imports', it => {
 		pass(pkg, ['./$foo.require', './$foo.string'], '#foo', { require: true });
 		pass(pkg, ['./$foo.require', './$foo.string'], 'foobar/#foo', { require: true });
 	});
+
+	// https://github.com/lukeed/resolve.exports/issues/34
+	it('imports["#features/*"] :: avoid lazy matching', () => {
+		let pkg: Package = {
+			name: 'test',
+			imports: {
+				'#features/*.css': './src/*.css',
+    		'#features/*.ts': './src/*.ts',
+			}
+		};
+		pass(pkg, './src/asdf/css.ts', '#features/asdf/css.ts');
+	});	
 });
 
 describe('$.exports', it => {


### PR DESCRIPTION
Fix for https://github.com/lukeed/resolve.exports/issues/34