### PR TITLE
Escape regexp content

### DIFF
--- a/src/RegExp.d.ts
+++ b/src/RegExp.d.ts
@@ -1,0 +1,3 @@
+interface RegExpConstructor {
+  escape(str: string): string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function conditions(options: t.Options): Set<t.Condition> {
 	return out;
 }
 
-const escape = RegExp.escape ?? ((str: string) => str.replaceAll('.', '\\.'));
+const escape = RegExp.escape ?? ((str: string) => str.replace(/\./g, '\\.'));
 
 export function walk(name: string, mapping: Mapping, input: string, options?: t.Options): string[] {
 	let entry = toEntry(name, input);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,6 +19,8 @@ export function conditions(options: t.Options): Set<t.Condition> {
 	return out;
 }
 
+const escape = RegExp.escape ?? ((str: string) => str.replaceAll('.', '\\.'));
+
 export function walk(name: string, mapping: Mapping, input: string, options?: t.Options): string[] {
 	let entry = toEntry(name, input);
 	let c = conditions(options || {});
@@ -44,7 +46,7 @@ export function walk(name: string, mapping: Mapping, input: string, options?: t.
 
 				if (!!~tmp) {
 					match = RegExp(
-						'^' + key.substring(0, tmp) + '(.*)' + key.substring(1+tmp) + '$'
+						'^' + escape(key.substring(0, tmp)) + '(.*)' + escape(key.substring(1+tmp)) + '$'
 					).exec(entry);
 
 					if (match && match[1]) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -646,7 +646,18 @@ describe('$.imports', it => {
 			}
 		};
 		pass(pkg, './src/asdf/css.ts', '#features/asdf/css.ts');
-	});	
+	});
+
+  it('imports["#features/*"] :: escape regexp', () => {
+		let pkg: Package = {
+			name: 'test',
+			imports: {
+				'#features/*.css': './src/*.css',
+			}
+		};
+		fail(pkg, '#features/unexists.scss', '#features/unexists.scss');
+	});
+
 });
 
 describe('$.exports', it => {


### PR DESCRIPTION
Fix for https://github.com/lukeed/resolve.exports/issues/38
Replaces https://github.com/lukeed/resolve.exports/pull/39

Use fast, built-in [RegExp.escape()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) with backward compatibility.